### PR TITLE
Add warning for nested JSON structures in i18n files; remove Black fr…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,6 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
 
   - repo: https://github.com/tcort/markdown-link-check
     rev: v3.13.6

--- a/src/i18n_check/checks/check_nested_i18n_src.py
+++ b/src/i18n_check/checks/check_nested_i18n_src.py
@@ -1,8 +1,61 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """
-Checks if the i18n-src file is a nested JSON object.
+Checks if i18n-dir contains JSON files with nested JSON objects.
 If yes, warns the user that this structure makes replacing invalid keys more difficult.
 
 Usage:
     python3 src/i18n_check/checks/check_nested_i18n_src.py
 """
+
+import json
+from pathlib import Path
+from i18n_check.utils import warn_on_nested_i18n_src, i18n_directory, read_json_file
+
+
+def is_nested_json(data):
+    """
+    Check if the JSON structure is nested.
+
+    Parameters
+    ----------
+    data : dict
+        The JSON data to check.
+
+    Returns
+    -------
+    bool
+        True if the JSON structure is nested, False otherwise.
+    """
+    if isinstance(data, dict):
+        return any(isinstance(value, dict) for value in data.values())
+    return False
+
+
+def check_i18n_files(directory):
+    """
+    Check all JSON files in the given directory for nested structures.
+
+    Parameters
+    ----------
+    directory : str
+        The directory path to check for JSON files.
+
+    Returns
+    -------
+    None
+    """
+    for file_path in Path(directory).rglob("*.json"):
+        try:
+            data = read_json_file(file_path)
+            if is_nested_json(data):
+                if warn_on_nested_i18n_src:
+                    print(f"Warning: Nested JSON structure detected in {file_path}")
+                    print(
+                        "i18n-check recommends using flat JSON files to allow easy find-and-replace operations."
+                    )
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"Error processing {file_path}: {e}")
+
+
+if __name__ == "__main__":
+    check_i18n_files(i18n_directory)

--- a/src/i18n_check/utils.py
+++ b/src/i18n_check/utils.py
@@ -130,7 +130,7 @@ def path_to_valid_key(p: str):
 
     Parameters
     ----------
-    p : list[str]
+    p : str
         The string of the directory path of a file that has a key.
 
     Returns

--- a/tests/test_frontend/test_i18n/test-i18n-src.json
+++ b/tests/test_frontend/test_i18n/test-i18n-src.json
@@ -5,5 +5,8 @@
   "sub_dir._global.hello_sub_dir": "Hello, sub directory!",
   "sub_dir.first_file.hello_sub_dir_first_file": "Hello, sub directory first file!",
   "sub_dir.second_file.hello_sub_dir_second_file": "Hello, sub directory second file!",
-  "test_file.hello_test_file": "Hello, test file!"
+  "test_file.hello_test_file": "Hello, test file!",
+  "_global.nested_example": {
+    "nestedKey": "This is a nested i18n key."
+  }
 }


### PR DESCRIPTION
…om pre-commit while keeping Ruff

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This introduces a new check for nested JSON structures in i18n files. If a nested structure is detected, a warning is displayed to the user. The warning can be disabled by setting `warn-on-nested-i18n-src` to false in the [.i18n-check.yaml](https://github.com/activist-org/i18n-check/blob/main/.i18n-check.yaml) configuration file.

Additionally, Black is removed from the pre-commit configuration.

### Related issue

- #5 
