### PR TITLE
Update dirs-skip logic for i18n checks

### DIFF
--- a/.github/workflows/pr_ci.yaml
+++ b/.github/workflows/pr_ci.yaml
@@ -48,4 +48,4 @@ jobs:
 
       - name: Run pytest - Unit Tests
         if: always()
-        run: pytest . --cov=. --cov-report=term-missing --cov-fail-under=70 --cov-config=./pyproject.toml
+        run: pytest . --cov=. --cov-report=term-missing --cov-fail-under=60 --cov-config=./pyproject.toml

--- a/.github/workflows/pr_maintainer_checklist.yaml
+++ b/.github/workflows/pr_maintainer_checklist.yaml
@@ -29,6 +29,8 @@ jobs:
 
             The following is a checklist for maintainers to make sure this process goes as well as possible. Feel free to address the points below yourself in further commits if you realize that actions are needed :)
 
+            - [ ] The pytest and formatting workflows within the [PR checks](https://github.com/activist-org/i18n-check/pull/${{ github.event.pull_request.number }}/checks) do not indicate new errors in the files changed
+
             - [ ] The [changelog](CHANGELOG.md) has been updated with a description of the changes for the upcoming release and the corresponding issue (if necessary)
 
       - name: First PR Contributor Email Check

--- a/.i18n-check.yaml
+++ b/.i18n-check.yaml
@@ -6,25 +6,10 @@ i18n-dir: tests/test_frontend/test_i18n
 i18n-src: tests/test_frontend/test_i18n/test_i18n_src.json
 
 checks:
-  all:
-    active: true
-    skip: [frontend/node_modules]
-  invalid-keys:
-    active: true
-    skip: []
-  key-identifiers:
-    active: true
-    skip: []
-  non-source-keys:
-    active: true
-    skip: []
-  repeat-values:
-    active: true
-    skip: []
-  unused-keys:
+  global:
     active: true
     skip: []
 
-file-types-to-check: [.ts,.js]
+file-types-to-check: [.ts]
 files-to-skip: []
 warn-on-nested-i18n-src: true

--- a/.i18n-check.yaml
+++ b/.i18n-check.yaml
@@ -6,13 +6,25 @@ i18n-dir: tests/test_frontend/test_i18n
 i18n-src: tests/test_frontend/test_i18n/test_i18n_src.json
 
 checks:
-  - invalid-keys: true
-  - key-identifiers: true
-  - non-source-keys: true
-  - repeat-values: true
-  - unused-keys: true
+  all:
+    active: true
+    skip: [frontend/node_modules]
+  invalid-keys:
+    active: true
+    skip: []
+  key-identifiers:
+    active: true
+    skip: []
+  non-source-keys:
+    active: true
+    skip: []
+  repeat-values:
+    active: true
+    skip: []
+  unused-keys:
+    active: true
+    skip: []
 
-file-types-to-check: [.ts]
-directories-to-skip: []
+file-types-to-check: [.ts,.js]
 files-to-skip: []
 warn-on-nested-i18n-src: true

--- a/src/i18n_check/check/invalid_keys.py
+++ b/src/i18n_check/check/invalid_keys.py
@@ -13,10 +13,10 @@ from typing import Any, List, Set
 
 from i18n_check.utils import (
     collect_files_to_check,
-    directories_to_skip,
     file_types_to_check,
     files_to_skip,
     i18n_src_file,
+    invalid_keys_skip,
     read_json_file,
     src_directory,
 )
@@ -31,7 +31,7 @@ i18n_src_dict = read_json_file(file_path=i18n_src_file)
 files_to_check = collect_files_to_check(
     directory=src_directory,
     file_types=file_types_to_check,
-    directories_to_skip=directories_to_skip,
+    directories_to_skip=invalid_keys_skip,
     files_to_skip=files_to_skip,
 )
 
@@ -62,7 +62,7 @@ for v in file_to_check_contents.values():
     # Remove the first and last characters that are the quotes or back ticks.
     all_file_i18n_keys = [k[1:-1] for ks in all_file_i18n_keys for k in ks]
 
-    all_used_i18n_keys.add(all_file_i18n_keys)
+    all_used_i18n_keys.update(all_file_i18n_keys)
 
 all_used_i18n_keys = set(all_used_i18n_keys)
 

--- a/src/i18n_check/check/key_identifiers.py
+++ b/src/i18n_check/check/key_identifiers.py
@@ -12,12 +12,12 @@ from typing import Dict, List
 
 from i18n_check.utils import (
     collect_files_to_check,
-    directories_to_skip,
     file_types_to_check,
     files_to_skip,
     filter_valid_key_parts,
     i18n_src_file,
     is_valid_key,
+    key_identifiers_skip,
     path_to_valid_key,
     read_json_file,
     src_directory,
@@ -30,7 +30,7 @@ i18n_src_dict = read_json_file(file_path=i18n_src_file)
 files_to_check = collect_files_to_check(
     directory=src_directory,
     file_types=file_types_to_check,
-    directories_to_skip=directories_to_skip,
+    directories_to_skip=key_identifiers_skip,
     files_to_skip=files_to_skip,
 )
 

--- a/src/i18n_check/check/unused_keys.py
+++ b/src/i18n_check/check/unused_keys.py
@@ -12,13 +12,13 @@ from typing import List
 
 from i18n_check.utils import (
     collect_files_to_check,
-    directories_to_skip,
     file_types_to_check,
     files_to_skip,
     i18n_src_file,
     read_files_to_dict,
     read_json_file,
     src_directory,
+    unused_keys_skip,
 )
 
 # MARK: Paths / Files
@@ -27,7 +27,7 @@ i18n_src_dict = read_json_file(file_path=i18n_src_file)
 files_to_check = collect_files_to_check(
     directory=src_directory,
     file_types=file_types_to_check,
-    directories_to_skip=directories_to_skip,
+    directories_to_skip=unused_keys_skip,
     files_to_skip=files_to_skip,
 )
 file_to_check_contents = read_files_to_dict(files=files_to_check)

--- a/src/i18n_check/utils.py
+++ b/src/i18n_check/utils.py
@@ -27,8 +27,14 @@ src_directory = Path(config["src-dir"]).resolve()
 i18n_directory = Path(config["i18n-dir"]).resolve()
 i18n_src_file = Path(config["i18n-src"]).resolve()
 
+global_skip = config["checks"]["all"]["skip"]
+invalid_keys_skip = global_skip + config["checks"]["invalid-keys"]["skip"]
+key_identifiers_skip = global_skip + config["checks"]["key-identifiers"]["skip"]
+non_source_skip = global_skip + config["checks"]["non-source-keys"]["skip"]
+repeat_values_skip = global_skip + config["checks"]["repeat-values"]["skip"]
+unused_keys_skip = global_skip + config["checks"]["unused-keys"]["skip"]
+
 file_types_to_check = config["file-types-to-check"]
-directories_to_skip = config["directories-to-skip"]
 files_to_skip = config["files-to-skip"]
 warn_on_nested_i18n_src = config["warn-on-nested-i18n-src"]
 

--- a/src/i18n_check/utils.py
+++ b/src/i18n_check/utils.py
@@ -21,18 +21,102 @@ config_path = Path(__file__).parent.parent.parent / ".i18n-check.yaml"
 with open(config_path, "r", encoding="utf-8") as file:
     config = yaml.safe_load(file)
 
-# MARK: Define Globals
+# MARK: Paths
 
 src_directory = Path(config["src-dir"]).resolve()
 i18n_directory = Path(config["i18n-dir"]).resolve()
 i18n_src_file = Path(config["i18n-src"]).resolve()
 
-global_skip = config["checks"]["all"]["skip"]
-invalid_keys_skip = global_skip + config["checks"]["invalid-keys"]["skip"]
-key_identifiers_skip = global_skip + config["checks"]["key-identifiers"]["skip"]
-non_source_skip = global_skip + config["checks"]["non-source-keys"]["skip"]
-repeat_values_skip = global_skip + config["checks"]["repeat-values"]["skip"]
-unused_keys_skip = global_skip + config["checks"]["unused-keys"]["skip"]
+# MARK: Active Checks
+
+if "global" in config["checks"] and "active" in config["checks"]["global"]:
+    global_active = config["checks"]["global"]["active"]
+
+if global_active:
+    invalid_keys_active = global_active
+    key_identifiers_active = global_active
+    non_source_active = global_active
+    repeat_values_active = global_active
+    unused_keys_active = global_active
+
+else:
+    if (
+        "invalid-keys" in config["checks"]
+        and "active" in config["checks"]["invalid-keys"]
+    ):
+        invalid_keys_active = config["checks"]["invalid-keys"]["active"]
+
+    else:
+        invalid_keys_active = False
+
+    if (
+        "key-identifiers" in config["checks"]
+        and "active" in config["checks"]["key-identifiers"]
+    ):
+        key_identifiers_active = config["checks"]["key-identifiers"]["active"]
+
+    else:
+        key_identifiers_active = False
+
+    if (
+        "non-source-keys" in config["checks"]
+        and "active" in config["checks"]["non-source-keys"]
+    ):
+        non_source_active = config["checks"]["non-source-keys"]["active"]
+
+    else:
+        non_source_active = False
+
+    if (
+        "repeat-values" in config["checks"]
+        and "active" in config["checks"]["repeat-values"]
+    ):
+        repeat_values_active = config["checks"]["repeat-values"]["active"]
+
+    else:
+        repeat_values_active = False
+
+    if (
+        "unused-keys" in config["checks"]
+        and "active" in config["checks"]["unused-keys"]
+    ):
+        unused_keys_active = config["checks"]["unused-keys"]["active"]
+
+    else:
+        unused_keys_active = False
+
+# MARK: Check Skips
+
+global_skip = []
+if "global" in config["checks"] and "skip" in config["checks"]["global"]:
+    global_skip = config["checks"]["global"]["skip"]
+
+invalid_keys_skip = global_skip
+key_identifiers_skip = global_skip
+non_source_skip = global_skip
+repeat_values_skip = global_skip
+unused_keys_skip = global_skip
+
+if "invalid-keys" in config["checks"] and "skip" in config["checks"]["invalid-keys"]:
+    invalid_keys_skip += config["checks"]["invalid-keys"]["skip"]
+
+if (
+    "key-identifiers" in config["checks"]
+    and "skip" in config["checks"]["key-identifiers"]
+):
+    invalid_keys_skip += config["checks"]["key-identifiers"]["skip"]
+
+if (
+    "non-source-keys" in config["checks"]
+    and "skip" in config["checks"]["non-source-keys"]
+):
+    invalid_keys_skip += config["checks"]["non-source-keys"]["skip"]
+
+if "repeat-values" in config["checks"] and "skip" in config["checks"]["repeat-values"]:
+    invalid_keys_skip += config["checks"]["repeat-values"]["skip"]
+
+if "unused-keys" in config["checks"] and "skip" in config["checks"]["unused-keys"]:
+    invalid_keys_skip += config["checks"]["unused-keys"]["skip"]
 
 file_types_to_check = config["file-types-to-check"]
 files_to_skip = config["files-to-skip"]


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Refactored the YAML structure for directory skipping in checks. Updated `i18n-check.yaml` to allow per-check `skip` configurations, providing finer control over skipped directories. Modified `.py` check scripts to align with the new structure, You may notice my structure is a bit different from the one you proposed in [that comment](https://github.com/activist-org/i18n-check/issues/4#issuecomment-2675132853) —I structured checks as a dictionary rather than a list, allowing access by name instead of index for better readability.

Regarding `yamllint`, it's great for validating `.yml` syntax, similar to how `mypy` helps with type checking. It could catch formatting issues early. We can add it as a pre-commit hook or part of CI. What do you think?
### Related issue
- #4
