### PR TITLE
Align `repeat-values` key suggestions with `invalid-keys` using shared directory structure

### DIFF
--- a/src/i18n_check/test_frontends/all_checks_fail/sub_dir/sub_dir_second_file.ts
+++ b/src/i18n_check/test_frontends/all_checks_fail/sub_dir/sub_dir_second_file.ts
@@ -1,6 +1,7 @@
 // This file contains the following i18n keys:
 //   - "i18n._global.hello_global"
 //   - "i18n._global.hello_global_repeat_value"
+//   - "i18n.hello_global_in_multiple_files"
 //   - "i18n._global.repeat_key"
 //   - "i18n.sub_dir._global.hello_sub_dir"
 //   - "i18n.sub_dir_second_file.hello_sub_dir_second_file"

--- a/src/i18n_check/test_frontends/all_checks_fail/test_file.ts
+++ b/src/i18n_check/test_frontends/all_checks_fail/test_file.ts
@@ -1,6 +1,8 @@
 // This file contains the following i18n keys:
 //   - "i18n._global.hello_global"
 //   - "i18n._global.hello_global_repeat_value"
+//   - "i18n.hello_global_in_single_file_repeat_value"
+//   - "i18n.hello_global_in_multiple_files"
 //   - "i18n._global.repeat_key"
 //   - "i18n.test_file.form_button_aria_label"
 //   - i18n.test_file.hello_test_file  // no quotes or backticks

--- a/src/i18n_check/test_frontends/all_checks_fail/test_i18n/test_i18n_src.json
+++ b/src/i18n_check/test_frontends/all_checks_fail/test_i18n/test_i18n_src.json
@@ -1,6 +1,10 @@
 {
   "i18n._global.hello_global": "Hello, global!",
   "i18n._global.hello_global_repeat_value": "hello, global!",
+  "i18n.hello_global_in_single_file": "hello, global single file!",
+  "i18n.hello_global_in_single_file_repeat_value": "hello, global single file!",
+  "i18n.hello_global_in_multiple_files": "hello, global multiple files!",
+  "i18n.hello_global_in_multiple_files_repeat_value": "hello, global multiple files!",
   "i18n._global.repeat_key": "This key is duplicated",
   "i18n._global.repeat_key": "This key is duplicated, but the value is not",
   "i18n._global.unused_i18n_key": "A key that's unused in the project.",
@@ -15,4 +19,5 @@
   },
   "i18n.test_file.repeat_key_lower": "this key is duplicated, but the value is not",
   "i18n.wrong_identifier_path.content_reference": "This key needs to be renamed"
+
 }

--- a/tests/checks/test_invalid_keys.py
+++ b/tests/checks/test_invalid_keys.py
@@ -56,8 +56,8 @@ invalid_format_pass, invalid_name_pass = audit_i18n_keys(
 @pytest.mark.parametrize(
     "i18n_map, expected_output",
     [
-        (len(i18n_map_fail), 12),
-        (len(map_keys_to_files()), 12),
+        (len(i18n_map_fail), 15),
+        (len(map_keys_to_files()), 15),
         (
             set(i18n_map_fail["i18n._global.hello_global_repeat_value"]),
             {"test_file", "sub_dir/sub_dir_first_file", "sub_dir/sub_dir_second_file"},
@@ -102,7 +102,7 @@ def test_audit_i18n_keys() -> None:
     Test audit_i18n_keys with various scenarios.
     """
     assert invalid_format_pass == []
-    assert len(invalid_name_fail) == 1
+    assert len(invalid_name_fail) == 4
     assert invalid_name_pass == {}
     assert invalid_format_fail == ["i18n.test_file.incorrectly-formatted-key"]
     assert (
@@ -121,9 +121,9 @@ def test_report_and_correct_keys_fail(capsys) -> None:
     output_msg = capsys.readouterr().out
 
     assert "There is 1 i18n key that is not formatted correctly" in output_msg
-    assert "There is 1 i18n key that is not named correctly." in output_msg
+    assert "There are 4 i18n keys that are not named correctly." in output_msg
     assert (
-        "Please rename the following key [current_key -> suggested_correction]:"
+        "Please rename the following keys [current_key -> suggested_correction]:"
         in output_msg
     )
     assert "i18n.wrong_identifier_path.content_reference" in output_msg

--- a/tests/checks/test_non_existent_keys.py
+++ b/tests/checks/test_non_existent_keys.py
@@ -49,8 +49,8 @@ all_i18n_used = get_used_i18n_keys()
     "used_keys, expected_output",
     [
         (len(i18n_used_pass), 6),
-        (len(i18n_used_fail), 12),
-        (len(all_i18n_used), 12),
+        (len(i18n_used_fail), 14),
+        (len(all_i18n_used), 14),
         (
             i18n_used_fail,
             {
@@ -66,6 +66,8 @@ all_i18n_used = get_used_i18n_keys()
                 "i18n.test_file.not_in_i18n_source_file",
                 "i18n.test_file.repeat_key_lower",
                 "i18n.wrong_identifier_path.content_reference",
+                "i18n.hello_global_in_single_file_repeat_value",
+                "i18n.hello_global_in_multiple_files",
             },
         ),
     ],

--- a/tests/checks/test_repeat_values.py
+++ b/tests/checks/test_repeat_values.py
@@ -50,7 +50,12 @@ pass_checks_json = read_json_file(
         # The second value will be filtered out by analyze_and_generate_repeat_value_report.
         (
             fail_checks_json,
-            {"hello global!": 2, "this key is duplicated but the value is not": 2},
+            {
+                "hello global!": 2,
+                "hello global single file!": 2,
+                "hello global multiple files!": 2,
+                "this key is duplicated but the value is not": 2,
+            },
         ),
     ],
 )
@@ -74,10 +79,18 @@ def test_multiple_repeats_with_common_prefix(capsys) -> None:
 
     assert "Repeat value: 'hello global!'" in fail_report
     assert "Number of instances: : 2" in fail_report
-    assert "Suggested new key: i18n._global.CONTENT_REFERENCE" in fail_report
+    assert (
+        "Suggested key change: i18n.hello_global_in_single_file -> i18n.test_file.hello_global_in_single_file"
+        in fail_report
+    )
+    assert "-> i18n.test_file.hello_global_in_single_file_repeat_value" in fail_report
 
     # Result remain unchanged (not removed).
-    assert fail_result == {"hello global!": 2}
+    assert fail_result == {
+        "hello global!": 2,
+        "hello global single file!": 2,
+        "hello global multiple files!": 2,
+    }
     assert pass_result == {}
 
 
@@ -94,7 +107,6 @@ def test_key_with_lower_suffix_ignored(capsys) -> None:
     )
 
     assert "three_lower" not in report
-    assert "Suggested new key" in report
     assert result == {"test": 3}
 
 

--- a/tests/checks/test_unused_keys.py
+++ b/tests/checks/test_unused_keys.py
@@ -44,7 +44,10 @@ UNUSED_PASS_KEYS = find_unused_keys(
 
 
 def test_find_unused_keys_behavior() -> None:
-    assert UNUSED_FAIL_KEYS == ["i18n._global.unused_i18n_key"]
+    assert UNUSED_FAIL_KEYS == [
+        "i18n.hello_global_in_multiple_files_repeat_value",
+        "i18n._global.unused_i18n_key",
+    ]
     assert UNUSED_PASS_KEYS == []
 
 
@@ -59,7 +62,7 @@ def test_print_unused_keys_fail_raises_value_error(capsys) -> None:
         print_unused_keys(UNUSED_FAIL_KEYS)
 
     output = capsys.readouterr().out
-    assert "❌ unused_keys error: There is 1 i18n key that is unused" in output
+    assert "❌ unused_keys error: There are 2 i18n keys that are unused" in output
     assert "i18n._global.unused_i18n_key" in output
 
 


### PR DESCRIPTION
### Contributor checklist


- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for i18n-check as described in the [testing section of the contributing guide](../CONTRIBUTING.md#testing)

---

### Description
Here’s a short and clear PR description following your structure:

* Updated the `repeat-values` check key suggestion logic to align with the `invalid-keys` script by considering shared directory structure.

* Added 2 repeated test keys for our two possibilities of a key mentioned in a single/multiple files to the `test_frontend` directory to trigger the new updates.

* Updated existing tests to reflect the new behavior.


### Related issue

- #50 
