### PR TITLE
added "add missing keys" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ i18n-check -gcf  # generate a configuration file
 i18n-check -gtf  # generate test frontends to experiment with
 i18n-check -a  # run all checks
 i18n-check -CHECK_ID  # run a specific check (see options below)
+i18n-check -mk -f -l de  # interactively add missing keys for German locale
 ```
 
 <a id="previews-"></a>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ i18n-check -gcf  # generate a configuration file
 i18n-check -gtf  # generate test frontends to experiment with
 i18n-check -a  # run all checks
 i18n-check -CHECK_ID  # run a specific check (see options below)
-i18n-check -mk -f -l de  # interactively add missing keys for German locale
+i18n-check -mk -f -l ENTER_ISO_2_CODE  # interactive mode to add missing keys
 ```
 
 <a id="previews-"></a>
@@ -125,6 +125,7 @@ There the following checks can ran across your codebase:
 
 - `invalid-keys` (`ik`): Does the source file have keys that don't match the above format or name conventions?
   - Rename them so i18n key usage is consistent and their scope is communicated in their name.
+  - Pass `--fix` (`-f`) to fix all naming issues automatically.
 - `non-existent-keys` (`nek`): Does the codebase include i18n keys that are not within the source file?
   - Check their validity and resolve if they should be added to the i18n files or replaced.
 - `unused-keys` (`uk`): Does the source file have keys that are not used in the codebase?
@@ -137,15 +138,19 @@ There the following checks can ran across your codebase:
   - Combine them so the localization team only needs to localize one of them.
 - `sorted-keys` (`sk`): Are the i18n source and target locale files sorted alphabetically?
   - Sort them alphabetically to reduce merge conflicts from the files changing.
+  - Pass `--fix` (`-f`) to sort the i18n files automatically.
 - `nested-keys` (`nk`): Do the i18n files contain nested JSON structures?
   - Flatten them to make replacing invalid keys easier with find-and-replace all.
 - `missing-keys` (`mk`): Are any keys from the source file missing in the locale files?
   - Add the missing keys to ensure all translations are complete.
   - Keys with empty string values are also considered missing.
+  - Pass `--fix --locale ENTER_ISO_2_CODE` (`-f -l ENTER_ISO_2_CODE`) to interactively add missing keys.
 - `aria-labels` (`al`): Do keys that end in `_aria_label` end in punctuation?
   - Remove the punctuation as it negatively affects screen reader experience.
+  - Pass `--fix` (`-f`) to remove punctuation automatically.
 - `alt-texts` (`at`): Do keys that end in `_alt_text` lack proper punctuation?
   - Add periods to the end to comply with alt text guidelines.
+  - Pass `--fix` (`-f`) to add periods automatically.
 
 Directions for how to fix the i18n files are provided when errors are raised. Checks can also be disabled in the workflow via options passed in the configuration YAML file.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -107,6 +107,7 @@ There the following checks can ran across your codebase:
 
 - ``invalid-keys`` (``ik``): Does the source file have keys that don't match the above format or name conventions?
     - Rename them so i18n key usage is consistent and their scope is communicated in their name.
+    - Pass ``--fix``` (``-f``) to fix all naming issues automatically.
 - ``non-existent-keys`` (``nek``): Does the codebase include i18n keys that are not within the source file?
     - Check their validity and resolve if they should be added to the i18n files or replaced.
 - ``unused-keys`` (``uk``): Does the source file have keys that are not used in the codebase?
@@ -119,15 +120,19 @@ There the following checks can ran across your codebase:
     - Combine them so the localization team only needs to localize one of them.
 - ``sorted-keys`` (``sk``): Are the i18n source and target locale files sorted alphabetically?
     - Sort them alphabetically to reduce merge conflicts from the files changing.
+    - Pass ``--fix`` (``-f``) to sort the i18n files automatically.
 - ``nested-keys`` (``nk``): Do the i18n files contain nested JSON structures?
     - Flatten them to make replacing invalid keys easier with find-and-replace all.
 - ``missing-keys`` (``mk``): Are any keys from the source file missing in the locale files?
     - Add the missing keys to ensure all translations are complete.
     - Keys with empty string values are also considered missing.
+    - Pass ``--fix --locale ENTER_ISO_2_CODE`` (``-f -l ENTER_ISO_2_CODE``) to interactively add missing keys.
 - ``aria-labels`` (``al``): Do keys that end in ``_aria_label`` end in punctuation?
     - Remove the punctuation as it negatively affects screen reader experience.
+    - Pass ``--fix`` (``-f``) to remove punctuation automatically.
 - ``alt-texts`` (``at``): Do keys that end in ``_alt_text`` lack proper punctuation?
     - Add periods to the end to comply with alt text guidelines.
+    - Pass ``--fix`` (``-f``) to add periods automatically.
 
 Directions for how to fix the i18n files are provided when errors are raised. Checks can also be disabled in the workflow via options passed in the configuration YAML file.
 

--- a/src/i18n_check/check/missing_keys.py
+++ b/src/i18n_check/check/missing_keys.py
@@ -15,7 +15,7 @@ Run the following script in terminal:
 import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from rich import print as rprint
 from rich.prompt import Prompt
@@ -285,7 +285,7 @@ def add_missing_keys_interactively(
 
 
 def check_missing_keys_with_fix(
-    fix_locale: str = None,
+    fix_locale: Optional[str] = None,
     i18n_src_dict: Dict[str, str] = i18n_src_dict,
     i18n_directory: Path = config_i18n_directory,
     locales_to_check: List[str] = config_missing_keys_locales_to_check,

--- a/src/i18n_check/check/missing_keys.py
+++ b/src/i18n_check/check/missing_keys.py
@@ -245,41 +245,43 @@ def add_missing_keys_interactively(
                     src_directory=config_src_directory,
                 )
 
-                rprint(f"[cyan]Key:[/cyan] {key}")
-                rprint(f"[cyan]Source value:[/cyan] '{source_value}'")
+                # Skip if the key isn't used in any file.
+                if missing_key_file_dict:
+                    rprint(f"[cyan]Key:[/cyan] {key}")
+                    rprint(f"[cyan]Source value:[/cyan] '{source_value}'")
 
-                missing_key_file_names = [
-                    f.split(path_separator)[-1] for f in missing_key_file_dict[key]
-                ]
-                rprint(f"[cyan]Used in:[/cyan] {', '.join(missing_key_file_names)}")
+                    missing_key_file_names = [
+                        f.split(path_separator)[-1] for f in missing_key_file_dict[key]
+                    ]
+                    rprint(f"[cyan]Used in:[/cyan] {', '.join(missing_key_file_names)}")
 
-                # Get translation from user.
-                translation = Prompt.ask(
-                    f"[green]Enter translation for '{key}'[/green]",
-                    default="",
-                    show_default=False,
-                )
-
-                if translation:
-                    # Add the translation to the locale dictionary.
-                    locale_dict[key] = translation
-
-                    # Check if sorted keys are required.
-                    is_sorted, sorted_keys = check_file_keys_sorted(locale_dict)
-                    if not is_sorted:
-                        # Sort the dictionary if keys should be ordered.
-                        locale_dict = dict(sorted(locale_dict.items()))
-
-                    with open(locale_file_path, "w", encoding="utf-8") as f:
-                        json.dump(locale_dict, f, indent=2, ensure_ascii=False)
-                        f.write("\n")
-
-                    rprint(
-                        f"[green]✅ Added translation for '{key}': '{translation}'[/green]\n"
+                    # Get translation from user.
+                    translation = Prompt.ask(
+                        f"[green]Enter translation for '{key}'[/green]",
+                        default="",
+                        show_default=False,
                     )
 
-                else:
-                    rprint(f"⏭️ Skipped '{key}' (empty translation)\n")
+                    if translation:
+                        # Add the translation to the locale dictionary.
+                        locale_dict[key] = translation
+
+                        # Check if sorted keys are required.
+                        is_sorted, sorted_keys = check_file_keys_sorted(locale_dict)
+                        if not is_sorted:
+                            # Sort the dictionary if keys should be ordered.
+                            locale_dict = dict(sorted(locale_dict.items()))
+
+                        with open(locale_file_path, "w", encoding="utf-8") as f:
+                            json.dump(locale_dict, f, indent=2, ensure_ascii=False)
+                            f.write("\n")
+
+                        rprint(
+                            f"[green]✅ Added translation for '{key}': '{translation}'[/green]\n"
+                        )
+
+                    else:
+                        rprint(f"⏭️ Skipped '{key}' (empty translation)\n")
 
     except KeyboardInterrupt:
         rprint("\n[yellow]Cancelled by user[/yellow]")

--- a/src/i18n_check/check/missing_keys.py
+++ b/src/i18n_check/check/missing_keys.py
@@ -178,7 +178,6 @@ def add_missing_keys_interactively(
     sys.exit(1)
         If the locale file doesn't exist or can't be processed.
     """
-    # Find the locale file
     locale_file_path = None
     for json_file in get_all_json_files(i18n_directory, path_separator):
         filename = json_file.split(path_separator)[-1].split(".")[0]
@@ -187,7 +186,9 @@ def add_missing_keys_interactively(
             break
 
     if not locale_file_path:
-        rprint(f"[red]❌ Error: Locale file '{locale}.json' not found in {i18n_directory}[/red]")
+        rprint(
+            f"[red]❌ Error: Locale file '{locale}.json' not found in {i18n_directory}[/red]"
+        )
         sys.exit(1)
 
     # Get missing keys for this locale
@@ -202,46 +203,46 @@ def add_missing_keys_interactively(
         return
 
     missing_keys, percentage = missing_keys_by_locale[locale]
-    
+
     rprint(f"\n[yellow]📝 Interactive mode for locale: {locale}[/yellow]")
-    rprint(f"[yellow]Missing keys: {len(missing_keys)} ({percentage:.1f}% missing)[/yellow]")
+    rprint(
+        f"[yellow]Missing keys: {len(missing_keys)} ({percentage:.1f}% missing)[/yellow]"
+    )
     rprint("[yellow]💡 Press Ctrl+C at any time to cancel[/yellow]\n")
 
-    # Load the current locale dictionary
     locale_dict = read_json_file(locale_file_path)
-    
+
     try:
         # Sort missing keys by the length of their source values (shortest first)
         def get_source_value_length(key: str) -> int:
             return len(i18n_src_dict.get(key, ""))
-        
+
         sorted_missing_keys = sorted(missing_keys, key=get_source_value_length)
-        
+
         for key in sorted_missing_keys:
             source_value = i18n_src_dict.get(key, "")
-            
-            # Display key information
+
             rprint(f"[cyan]Key:[/cyan] {key}")
             rprint(f"[cyan]Source value:[/cyan] '{source_value}'")
-            
+
             # Find source files where this key is used (this is a simplified approach)
             rprint(f"[cyan]Source file:[/cyan] {config_i18n_src_file}")
-            
+
             # Get translation from user
             translation = Prompt.ask(
                 f"[green]Enter translation for '{key}'[/green]",
                 default="",
-                show_default=False
+                show_default=False,
             )
-            
+
             if translation:
                 # Add the translation to the locale dictionary
                 locale_dict[key] = translation
-                
-                # Save the updated dictionary to file
+
                 # Check if sorted keys are required (from config or import sorted_keys functionality)
                 try:
                     from i18n_check.check.sorted_keys import check_file_keys_sorted
+
                     is_sorted, sorted_keys = check_file_keys_sorted(locale_dict)
                     if not is_sorted:
                         # Sort the dictionary if keys should be ordered
@@ -249,32 +250,35 @@ def add_missing_keys_interactively(
                 except ImportError:
                     # If sorted_keys module is not available, just keep original order
                     pass
-                
-                # Write the updated dictionary back to the file
+
                 with open(locale_file_path, "w", encoding="utf-8") as f:
                     json.dump(locale_dict, f, indent=2, ensure_ascii=False)
                     f.write("\n")
-                
-                rprint(f"[green]✅ Added translation for '{key}': '{translation}'[/green]\n")
+
+                rprint(
+                    f"[green]✅ Added translation for '{key}': '{translation}'[/green]\n"
+                )
             else:
                 rprint(f"[yellow]⏭️  Skipped '{key}' (empty translation)[/yellow]\n")
-    
+
     except KeyboardInterrupt:
         rprint("\n[yellow]🚪 Cancelled by user[/yellow]")
         sys.exit(0)
-    
+
     # Show final status
     remaining_missing = get_missing_keys_by_locale(
         i18n_src_dict=i18n_src_dict,
         i18n_directory=i18n_directory,
         locales_to_check=[locale],
     )
-    
+
     if locale not in remaining_missing:
         rprint(f"[green]🎉 All keys have been added to {locale}.json![/green]")
     else:
         remaining_count = len(remaining_missing[locale][0])
-        rprint(f"[yellow]📊 {remaining_count} keys still missing in {locale}.json[/yellow]")
+        rprint(
+            f"[yellow]📊 {remaining_count} keys still missing in {locale}.json[/yellow]"
+        )
 
 
 # MARK: Main Check with Fix Option

--- a/src/i18n_check/check/nested_keys.py
+++ b/src/i18n_check/check/nested_keys.py
@@ -12,17 +12,12 @@ Run the following script in terminal:
 """
 
 import json
-import os
 from pathlib import Path
 from typing import Dict
 
 from rich import print as rprint
 
-from i18n_check.utils import config_i18n_directory, read_json_file
-
-path_separator = "/"
-if os.name == "nt":
-    path_separator = "\\"
+from i18n_check.utils import config_i18n_directory, path_separator, read_json_file
 
 # MARK: Is Nested
 

--- a/src/i18n_check/check/repeat_values.py
+++ b/src/i18n_check/check/repeat_values.py
@@ -80,7 +80,7 @@ def analyze_and_generate_repeat_value_report(
 
     keys_to_remove = []
     for repeat_value in json_repeat_value_counts:
-        i18n_keys = [
+        repeat_value_i18n_keys = [
             k
             for k, v in i18n_src_dict.items()
             if repeat_value == lower_and_remove_punctuation(text=v)
@@ -88,17 +88,19 @@ def analyze_and_generate_repeat_value_report(
         ]
 
         # Needed as we're removing keys that are set to lowercase above.
-        if len(i18n_keys) > 1:
+        if len(repeat_value_i18n_keys) > 1:
             repeat_value_error_report += (
                 f"\n\nRepeat value: '{repeat_value}'"
-                f"\nNumber of instances: {len(i18n_keys)}"
-                f"\nKeys: {', '.join(i18n_keys)}"
+                f"\nNumber of instances: {len(repeat_value_i18n_keys)}"
+                f"\nKeys: {', '.join(repeat_value_i18n_keys)}"
             )
 
             # Use the methods from the invalid keys check to assure that results are consistent.
             repeat_value_key_file_dict = map_keys_to_files(
                 i18n_src_dict={
-                    k: v for k, v in i18n_src_dict.items() if k in i18n_keys
+                    k: v
+                    for k, v in i18n_src_dict.items()
+                    if k in repeat_value_i18n_keys
                 },
                 src_directory=config_src_directory,
             )

--- a/src/i18n_check/cli/main.py
+++ b/src/i18n_check/cli/main.py
@@ -272,9 +272,12 @@ def main() -> None:
     if args.missing_keys:
         if args.fix and args.locale:
             from i18n_check.check.missing_keys import check_missing_keys_with_fix
+
             check_missing_keys_with_fix(fix_locale=args.locale)
         elif args.fix and not args.locale:
-            rprint("[red]❌ Error: --locale (-l) is required when using --fix (-f) with --missing-keys (-mk)[/red]")
+            rprint(
+                "[red]❌ Error: --locale (-l) is required when using --fix (-f) with --missing-keys (-mk)[/red]"
+            )
             rprint("[yellow]💡 Example: i18n-check -mk -f -l de[/yellow]")
             sys.exit(1)
         else:

--- a/src/i18n_check/cli/main.py
+++ b/src/i18n_check/cli/main.py
@@ -15,6 +15,7 @@ from i18n_check.check.invalid_keys import (
     invalid_keys_by_name,
     report_and_correct_keys,
 )
+from i18n_check.check.missing_keys import check_missing_keys_with_fix
 from i18n_check.check.sorted_keys import check_all_files_sorted
 from i18n_check.cli.generate_config_file import generate_config_file
 from i18n_check.cli.generate_test_frontends import generate_test_frontends
@@ -61,7 +62,7 @@ def main() -> None:
     >>> i18n-check --generate-config-file  # -gcf
     >>> i18n-check --invalid-keys  # -ik
     >>> i18n-check --all-checks  # -a
-    >>> i18n-check --missing-keys --fix --locale de  # Interactive mode to add missing keys for German
+    >>> i18n-check --missing-keys --fix --locale ENTER_ISO_2_CODE  # interactive mode to add missing keys
     """
     # MARK: CLI Base
 
@@ -271,17 +272,18 @@ def main() -> None:
 
     if args.missing_keys:
         if args.fix and args.locale:
-            from i18n_check.check.missing_keys import check_missing_keys_with_fix
-
             check_missing_keys_with_fix(fix_locale=args.locale)
+
         elif args.fix and not args.locale:
             rprint(
                 "[red]❌ Error: --locale (-l) is required when using --fix (-f) with --missing-keys (-mk)[/red]"
             )
             rprint("[yellow]💡 Example: i18n-check -mk -f -l de[/yellow]")
             sys.exit(1)
+
         else:
             run_check("missing_keys")
+
         return
 
     if args.aria_labels:

--- a/src/i18n_check/test_frontends/all_checks_fail/test_i18n/test_i18n_locale.json
+++ b/src/i18n_check/test_frontends/all_checks_fail/test_i18n/test_i18n_locale.json
@@ -1,7 +1,7 @@
 {
-  "i18n.test_file.hello_test_file": "",
   "i18n._global.hello_global": "Hello, global in another language!",
-  "i18n.test_file.form_button_aria_label": "Click here to submit the form in another language.",
   "i18n._global.not_in_i18n_src": "A reference that can't be used.",
-  "i18n.sub_dir_first_file.hello_sub_dir_first_file": ""
+  "i18n.sub_dir_first_file.hello_sub_dir_first_file": "",
+  "i18n.test_file.form_button_aria_label": "Click here to submit the form in another language.",
+  "i18n.test_file.hello_test_file": ""
 }

--- a/tests/checks/test_invalid_keys.py
+++ b/tests/checks/test_invalid_keys.py
@@ -21,14 +21,14 @@ fail_dir = (
     / "test_frontends"
     / "all_checks_fail"
 )
-fail_checks_json = read_json_file(
+fail_checks_src_json = read_json_file(
     file_path=fail_dir / "test_i18n" / "test_i18n_src.json"
 )
 i18n_map_fail = map_keys_to_files(
-    i18n_src_dict=fail_checks_json, src_directory=fail_dir
+    i18n_src_dict=fail_checks_src_json, src_directory=fail_dir
 )
 
-fail_checks_json_path = fail_dir / "test_i18n" / "test_i18n_src.json"
+fail_checks_src_json_path = fail_dir / "test_i18n" / "test_i18n_src.json"
 fail_checks_test_file_path = fail_dir / "test_file.ts"
 fail_checks_sub_dir_first_file_path = fail_dir / "sub_dir" / "sub_dir_first_file.ts"
 fail_checks_sub_dir_second_file_path = fail_dir / "sub_dir" / "sub_dir_second_file.ts"
@@ -44,11 +44,11 @@ pass_dir = (
     / "test_frontends"
     / "all_checks_pass"
 )
-pass_checks_json = read_json_file(
+pass_checks_src_json = read_json_file(
     file_path=pass_dir / "test_i18n" / "test_i18n_src.json"
 )
 i18n_map_pass = map_keys_to_files(
-    i18n_src_dict=pass_checks_json, src_directory=pass_dir
+    i18n_src_dict=pass_checks_src_json, src_directory=pass_dir
 )
 
 invalid_format_pass, invalid_name_pass = audit_i18n_keys(
@@ -168,7 +168,7 @@ def test_report_and_correct_keys_fail_fix_mode(capsys):
 
     # Return to old state before string replacement:
     replace_text_in_file(
-        path=fail_checks_json_path,
+        path=fail_checks_src_json_path,
         old="i18n.test_file.content_reference",
         new="i18n.wrong_identifier_path.content_reference",
     )
@@ -180,12 +180,12 @@ def test_report_and_correct_keys_fail_fix_mode(capsys):
 
     # Repeat value keys as well:
     replace_text_in_file(
-        path=fail_checks_json_path,
+        path=fail_checks_src_json_path,
         old="i18n._global.repeat_value_multiple_files",
         new="i18n.repeat_value_multiple_files",
     )
     replace_text_in_file(
-        path=fail_checks_json_path,
+        path=fail_checks_src_json_path,
         old="i18n.test_file.repeat_value_single_file",
         new="i18n.repeat_value_single_file",
     )

--- a/tests/checks/test_missing_keys.py
+++ b/tests/checks/test_missing_keys.py
@@ -178,12 +178,12 @@ def test_add_missing_keys_interactively_nonexistent_locale(tmp_path: Path) -> No
     i18n_dir.mkdir(parents=True)
 
     src_file = i18n_dir / "src.json"
-    src_file.write_text('{"key1": "value1"}', encoding="utf-8")
+    src_file.write_text('{"key_0": "value_0"}', encoding="utf-8")
 
     with pytest.raises(SystemExit):
         add_missing_keys_interactively(
             locale="nonexistent",
-            i18n_src_dict={"key1": "value1"},
+            i18n_src_dict={"key_0": "value_0"},
             i18n_directory=i18n_dir,
         )
 
@@ -195,12 +195,14 @@ def test_add_missing_keys_interactively_no_missing_keys(tmp_path: Path, capsys) 
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
 
-    locale_file = i18n_dir / "de.json"
-    locale_file.write_text('{"key1": "wert1", "key2": "wert2"}', encoding="utf-8")
+    locale_file = i18n_dir / "locale.json"
+    locale_file.write_text(
+        '{"key_0": "locale_value_0", "key_1": "locale_value_1"}', encoding="utf-8"
+    )
 
     add_missing_keys_interactively(
-        locale="de",
-        i18n_src_dict={"key1": "value1", "key2": "value2"},
+        locale="locale",
+        i18n_src_dict={"key_0": "value_0", "key_1": "value_1"},
         i18n_directory=i18n_dir,
     )
 
@@ -218,23 +220,23 @@ def test_add_missing_keys_interactively_with_translations(
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
 
-    locale_file = i18n_dir / "de.json"
-    locale_file.write_text('{"key2": "wert2"}', encoding="utf-8")
+    locale_file = i18n_dir / "locale.json"
+    locale_file.write_text('{"key_1": "locale_value_1"}', encoding="utf-8")
 
     # Mock user input: first translation, skip second
     mock_prompt.side_effect = ["german translation", ""]
 
     add_missing_keys_interactively(
-        locale="de",
-        i18n_src_dict={"key1": "value1", "key2": "value2", "key3": "value3"},
+        locale="locale",
+        i18n_src_dict={"key_0": "value_0", "key_1": "value_1", "key_2": "value_2"},
         i18n_directory=i18n_dir,
     )
 
     updated_content = json.loads(locale_file.read_text(encoding="utf-8"))
     expected_content = {
-        "key1": "german translation",
-        "key2": "wert2",
-        # key3 should not be present since it was skipped
+        "key_0": "german translation",
+        "key_1": "locale_value_1",
+        # key_2 should not be present since it was skipped.
     }
 
     assert updated_content == expected_content
@@ -250,16 +252,15 @@ def test_add_missing_keys_interactively_keyboard_interrupt(
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
 
-    locale_file = i18n_dir / "de.json"
-    locale_file.write_text('{"key2": "wert2"}', encoding="utf-8")
+    locale_file = i18n_dir / "locale.json"
+    locale_file.write_text('{"key_1": "locale_value_1"}', encoding="utf-8")
 
-    # Mock KeyboardInterrupt
     mock_prompt.side_effect = KeyboardInterrupt()
 
     with pytest.raises(SystemExit):
         add_missing_keys_interactively(
-            locale="de",
-            i18n_src_dict={"key1": "value1", "key2": "value2"},
+            locale="locale",
+            i18n_src_dict={"key_0": "value_0", "key_1": "value_1"},
             i18n_directory=i18n_dir,
         )
 
@@ -286,7 +287,7 @@ def test_check_missing_keys_with_fix_with_locale(mock_add_function) -> None:
     """
     check_missing_keys_with_fix(
         fix_locale="de",
-        i18n_src_dict={"key1": "value1"},
+        i18n_src_dict={"key_0": "value_0"},
         i18n_directory=Path("/tmp"),
         locales_to_check=[],
     )
@@ -294,7 +295,7 @@ def test_check_missing_keys_with_fix_with_locale(mock_add_function) -> None:
     # Verify the interactive function was called with correct parameters
     mock_add_function.assert_called_once_with(
         locale="de",
-        i18n_src_dict={"key1": "value1"},
+        i18n_src_dict={"key_0": "value_0"},
         i18n_directory=Path("/tmp"),
     )
 

--- a/tests/checks/test_missing_keys.py
+++ b/tests/checks/test_missing_keys.py
@@ -176,10 +176,10 @@ def test_add_missing_keys_interactively_nonexistent_locale(tmp_path: Path) -> No
     """
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
-    
+
     src_file = i18n_dir / "src.json"
     src_file.write_text('{"key1": "value1"}', encoding="utf-8")
-    
+
     with pytest.raises(SystemExit):
         add_missing_keys_interactively(
             locale="nonexistent",
@@ -194,64 +194,68 @@ def test_add_missing_keys_interactively_no_missing_keys(tmp_path: Path, capsys) 
     """
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
-    
+
     locale_file = i18n_dir / "de.json"
     locale_file.write_text('{"key1": "wert1", "key2": "wert2"}', encoding="utf-8")
-    
+
     add_missing_keys_interactively(
         locale="de",
         i18n_src_dict={"key1": "value1", "key2": "value2"},
         i18n_directory=i18n_dir,
     )
-    
+
     captured = capsys.readouterr()
     assert "All keys are present" in captured.out
 
 
-@patch('i18n_check.check.missing_keys.Prompt.ask')
-def test_add_missing_keys_interactively_with_translations(mock_prompt, tmp_path: Path) -> None:
+@patch("i18n_check.check.missing_keys.Prompt.ask")
+def test_add_missing_keys_interactively_with_translations(
+    mock_prompt, tmp_path: Path
+) -> None:
     """
     Test that add_missing_keys_interactively adds translations and sorts keys.
     """
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
-    
+
     locale_file = i18n_dir / "de.json"
     locale_file.write_text('{"key2": "wert2"}', encoding="utf-8")
-    
+
     # Mock user input: first translation, skip second
     mock_prompt.side_effect = ["german translation", ""]
-    
+
     add_missing_keys_interactively(
         locale="de",
         i18n_src_dict={"key1": "value1", "key2": "value2", "key3": "value3"},
         i18n_directory=i18n_dir,
     )
-    
+
     updated_content = json.loads(locale_file.read_text(encoding="utf-8"))
     expected_content = {
         "key1": "german translation",
         "key2": "wert2",
         # key3 should not be present since it was skipped
     }
-    
+
     assert updated_content == expected_content
 
 
-@patch('i18n_check.check.missing_keys.Prompt.ask')  
-def test_add_missing_keys_interactively_keyboard_interrupt(mock_prompt, tmp_path: Path) -> None:
+@patch("i18n_check.check.missing_keys.Prompt.ask")
+def test_add_missing_keys_interactively_keyboard_interrupt(
+    mock_prompt, tmp_path: Path
+) -> None:
     """
     Test that add_missing_keys_interactively handles KeyboardInterrupt gracefully.
     """
     i18n_dir = tmp_path / "i18n"
     i18n_dir.mkdir(parents=True)
-    
+
     locale_file = i18n_dir / "de.json"
     locale_file.write_text('{"key2": "wert2"}', encoding="utf-8")
-    
+
     # Mock KeyboardInterrupt
     mock_prompt.side_effect = KeyboardInterrupt()
-    
+
     with pytest.raises(SystemExit):
         add_missing_keys_interactively(
             locale="de",
@@ -270,12 +274,12 @@ def test_check_missing_keys_with_fix_no_locale(capsys) -> None:
         i18n_directory=pass_dir,
         locales_to_check=[],
     )
-    
+
     captured = capsys.readouterr()
     assert "missing_keys success" in captured.out
 
 
-@patch('i18n_check.check.missing_keys.add_missing_keys_interactively')
+@patch("i18n_check.check.missing_keys.add_missing_keys_interactively")
 def test_check_missing_keys_with_fix_with_locale(mock_add_function) -> None:
     """
     Test that check_missing_keys_with_fix calls interactive function when locale is provided.
@@ -286,7 +290,7 @@ def test_check_missing_keys_with_fix_with_locale(mock_add_function) -> None:
         i18n_directory=Path("/tmp"),
         locales_to_check=[],
     )
-    
+
     # Verify the interactive function was called with correct parameters
     mock_add_function.assert_called_once_with(
         locale="de",

--- a/tests/checks/test_non_existent_keys.py
+++ b/tests/checks/test_non_existent_keys.py
@@ -21,11 +21,11 @@ fail_dir = (
     / "test_frontends"
     / "all_checks_fail"
 )
-fail_checks_json = read_json_file(
+fail_checks_src_json = read_json_file(
     file_path=fail_dir / "test_i18n" / "test_i18n_src.json"
 )
 i18n_used_fail = get_used_i18n_keys(
-    i18n_src_dict=fail_checks_json, src_directory=fail_dir
+    i18n_src_dict=fail_checks_src_json, src_directory=fail_dir
 )
 
 pass_dir = (
@@ -35,11 +35,11 @@ pass_dir = (
     / "test_frontends"
     / "all_checks_pass"
 )
-pass_checks_json = read_json_file(
+pass_checks_src_json = read_json_file(
     file_path=pass_dir / "test_i18n" / "test_i18n_src.json"
 )
 i18n_used_pass = get_used_i18n_keys(
-    i18n_src_dict=pass_checks_json, src_directory=pass_dir
+    i18n_src_dict=pass_checks_src_json, src_directory=pass_dir
 )
 
 all_i18n_used = get_used_i18n_keys()
@@ -96,7 +96,7 @@ def test_validate_fail_i18n_keys(capsys) -> None:
     """
     with pytest.raises(SystemExit):
         validate_i18n_keys(
-            all_used_i18n_keys=i18n_used_fail, i18n_src_dict=fail_checks_json
+            all_used_i18n_keys=i18n_used_fail, i18n_src_dict=fail_checks_src_json
         )
 
     msg = capsys.readouterr().out.replace("\n", "")
@@ -111,7 +111,7 @@ def test_validate_pass_i18n_keys(capsys) -> None:
     """
     # For pass case, it should not raise an error.
     validate_i18n_keys(
-        all_used_i18n_keys=i18n_used_pass, i18n_src_dict=pass_checks_json
+        all_used_i18n_keys=i18n_used_pass, i18n_src_dict=pass_checks_src_json
     )
     pass_result = capsys.readouterr().out
     cleaned_pass_result = re.sub(r"\x1b\[.*?m", "", pass_result).strip()

--- a/tests/checks/test_non_source_keys.py
+++ b/tests/checks/test_non_source_keys.py
@@ -31,15 +31,15 @@ pass_dir = (
     / "all_checks_pass"
     / "test_i18n"
 )
-fail_checks_json = read_json_file(file_path=fail_dir / "test_i18n_src.json")
-pass_checks_json = read_json_file(file_path=pass_dir / "test_i18n_src.json")
+fail_checks_src_json = read_json_file(file_path=fail_dir / "test_i18n_src.json")
+pass_checks_src_json = read_json_file(file_path=pass_dir / "test_i18n_src.json")
 
 non_source_keys_fail = get_non_source_keys(
-    i18n_src_dict=fail_checks_json,
+    i18n_src_dict=fail_checks_src_json,
     i18n_directory=fail_dir,
 )
 non_source_keys_pass = get_non_source_keys(
-    i18n_src_dict=pass_checks_json,
+    i18n_src_dict=pass_checks_src_json,
     i18n_directory=pass_dir,
 )
 

--- a/tests/checks/test_repeat_keys.py
+++ b/tests/checks/test_repeat_keys.py
@@ -13,7 +13,7 @@ from i18n_check.check.repeat_keys import (
     validate_repeat_keys,
 )
 
-fail_checks_json = (
+fail_checks_src_json = (
     Path(__file__).parent.parent.parent
     / "src"
     / "i18n_check"
@@ -22,7 +22,7 @@ fail_checks_json = (
     / "test_i18n"
     / "test_i18n_src.json"
 )
-pass_checks_json = (
+pass_checks_src_json = (
     Path(__file__).parent.parent.parent
     / "src"
     / "i18n_check"
@@ -37,7 +37,7 @@ pass_checks_json = (
     "json_str,expected",
     [
         (
-            fail_checks_json,
+            fail_checks_src_json,
             {
                 "i18n._global.repeat_key": [
                     "This key is duplicated",
@@ -45,7 +45,7 @@ pass_checks_json = (
                 ]
             },
         ),
-        (pass_checks_json, {}),
+        (pass_checks_src_json, {}),
         (
             '{"a": 1, "b": 2, "a": 3, "b": 4, "c": 5}',
             {"a": ["1", "3"], "b": ["2", "4"]},
@@ -75,7 +75,7 @@ def test_invalid_json(json_str) -> None:
     "file_path,expected_duplicates",
     [
         (
-            fail_checks_json,
+            fail_checks_src_json,
             {
                 "i18n._global.repeat_key": [
                     "This key is duplicated",
@@ -83,7 +83,7 @@ def test_invalid_json(json_str) -> None:
                 ]
             },
         ),
-        (pass_checks_json, {}),
+        (pass_checks_src_json, {}),
     ],
 )
 def test_check_file(file_path, expected_duplicates) -> None:

--- a/tests/checks/test_repeat_values.py
+++ b/tests/checks/test_repeat_values.py
@@ -19,7 +19,7 @@ from i18n_check.utils import read_json_file
 # repeat values across the repo
 json_repeat_value_counts = get_repeat_value_counts(i18n_src_dict)
 
-fail_checks_json = read_json_file(
+fail_checks_src_json = read_json_file(
     file_path=Path(__file__).parent.parent.parent
     / "src"
     / "i18n_check"
@@ -28,7 +28,7 @@ fail_checks_json = read_json_file(
     / "test_i18n"
     / "test_i18n_src.json"
 )
-pass_checks_json = read_json_file(
+pass_checks_src_json = read_json_file(
     file_path=Path(__file__).parent.parent.parent
     / "src"
     / "i18n_check"
@@ -46,10 +46,10 @@ pass_checks_json = read_json_file(
         ({}, {}),
         # Unicode/special characters.
         ({"key_0": "café", "key_1": "CAFÉ", "key_2": "café"}, {"café": 3}),
-        (pass_checks_json, {}),
+        (pass_checks_src_json, {}),
         # The second value will be filtered out by analyze_and_generate_repeat_value_report.
         (
-            fail_checks_json,
+            fail_checks_src_json,
             {
                 "hello global!": 2,
                 "hello single file!": 2,
@@ -71,10 +71,10 @@ def test_get_repeat_value_counts(
 
 def test_multiple_repeats_with_common_prefix(capsys) -> None:
     fail_result, fail_report = analyze_and_generate_repeat_value_report(
-        fail_checks_json, get_repeat_value_counts(fail_checks_json)
+        fail_checks_src_json, get_repeat_value_counts(fail_checks_src_json)
     )
     pass_result, pass_report = analyze_and_generate_repeat_value_report(
-        pass_checks_json, get_repeat_value_counts(pass_checks_json)
+        pass_checks_src_json, get_repeat_value_counts(pass_checks_src_json)
     )
 
     assert "Repeat value: 'hello global!'" in fail_report
@@ -118,7 +118,7 @@ def test_key_with_lower_suffix_ignored(capsys) -> None:
 def test_validate_repeat_values_behavior(capsys) -> None:
     with pytest.raises(SystemExit):
         validate_repeat_values(
-            json_repeat_value_counts=get_repeat_value_counts(fail_checks_json),
+            json_repeat_value_counts=get_repeat_value_counts(fail_checks_src_json),
             repeat_value_error_report="",
         )
         assert (
@@ -127,7 +127,7 @@ def test_validate_repeat_values_behavior(capsys) -> None:
         )
 
     validate_repeat_values(
-        json_repeat_value_counts=get_repeat_value_counts(pass_checks_json),
+        json_repeat_value_counts=get_repeat_value_counts(pass_checks_src_json),
         repeat_value_error_report="",
     )
     output = capsys.readouterr().out

--- a/tests/checks/test_repeat_values.py
+++ b/tests/checks/test_repeat_values.py
@@ -45,7 +45,7 @@ pass_checks_json = read_json_file(
         # Empty dicts.
         ({}, {}),
         # Unicode/special characters.
-        ({"key1": "café", "key2": "CAFÉ", "key3": "café"}, {"café": 3}),
+        ({"key_0": "café", "key_1": "CAFÉ", "key_2": "café"}, {"café": 3}),
         (pass_checks_json, {}),
         # The second value will be filtered out by analyze_and_generate_repeat_value_report.
         (

--- a/tests/checks/test_sorted_keys.py
+++ b/tests/checks/test_sorted_keys.py
@@ -24,7 +24,7 @@ fail_dir = (
     / "test_frontends"
     / "all_checks_fail"
 )
-fail_checks_json_path = fail_dir / "test_i18n" / "test_i18n_src.json"
+fail_checks_src_json_path = fail_dir / "test_i18n" / "test_i18n_src.json"
 
 pass_dir = (
     Path(__file__).parent.parent.parent
@@ -33,7 +33,7 @@ pass_dir = (
     / "test_frontends"
     / "all_checks_pass"
 )
-pass_checks_json_path = pass_dir / "test_i18n" / "test_i18n_src.json"
+pass_checks_src_json_path = pass_dir / "test_i18n" / "test_i18n_src.json"
 
 
 class TestCheckKeysAreSorted:
@@ -103,7 +103,7 @@ class TestCheckFileSortedKeys:
         """
         Test that the pass frontend file has sorted keys.
         """
-        is_sorted, sorted_keys = check_file_sorted(pass_checks_json_path)
+        is_sorted, sorted_keys = check_file_sorted(pass_checks_src_json_path)
 
         assert is_sorted is True
         assert len(sorted_keys) > 0
@@ -112,7 +112,7 @@ class TestCheckFileSortedKeys:
         """
         Test that the fail frontend file has unsorted keys.
         """
-        is_sorted, sorted_keys = check_file_sorted(fail_checks_json_path)
+        is_sorted, sorted_keys = check_file_sorted(fail_checks_src_json_path)
 
         assert is_sorted is False
         assert len(sorted_keys) > 0

--- a/tests/checks/test_unused_keys.py
+++ b/tests/checks/test_unused_keys.py
@@ -14,7 +14,7 @@ from i18n_check.check.unused_keys import (
 )
 from i18n_check.utils import read_json_file
 
-fail_checks_json = (
+fail_checks_src_json = (
     Path(__file__).parent.parent.parent
     / "src"
     / "i18n_check"
@@ -23,7 +23,7 @@ fail_checks_json = (
     / "test_i18n"
     / "test_i18n_src.json"
 )
-pass_checks_json = (
+pass_checks_src_json = (
     Path(__file__).parent.parent.parent
     / "src"
     / "i18n_check"
@@ -34,11 +34,11 @@ pass_checks_json = (
 )
 
 UNUSED_FAIL_KEYS = find_unused_keys(
-    i18n_src_dict=read_json_file(file_path=fail_checks_json),
+    i18n_src_dict=read_json_file(file_path=fail_checks_src_json),
     files_to_check_contents=files_to_check_contents,
 )
 UNUSED_PASS_KEYS = find_unused_keys(
-    i18n_src_dict=read_json_file(file_path=pass_checks_json),
+    i18n_src_dict=read_json_file(file_path=pass_checks_src_json),
     files_to_check_contents=files_to_check_contents,
 )
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for i18n-check as described in the [testing section of the contributing guide](../CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
- Interactive CLI Mode: Added the ability to interactively add missing translation keys via the command line
- Command: `i18n-check -mk -f -l <locale> (e.g., i18n-check -mk -f -l de)`
### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #41 
